### PR TITLE
Add Relay Client Concurrency

### DIFF
--- a/cmd/gateway_server/internal/controllers/relay.go
+++ b/cmd/gateway_server/internal/controllers/relay.go
@@ -87,6 +87,7 @@ func (c *RelayController) HandleRelay(ctx *fasthttp.RequestCtx) {
 func (c *RelayController) concurrentRelay(req *models.SendRelayRequest, session *models.Session) (*models.SendRelayResponse, error) {
 	// Create a channel to receive results
 	resultCh := make(chan *models.SendRelayResponse, 1)
+	defer close(resultCh)
 	wg := sync.WaitGroup{}
 	for _, node := range session.Nodes {
 		node := node

--- a/cmd/gateway_server/internal/controllers/relay.go
+++ b/cmd/gateway_server/internal/controllers/relay.go
@@ -87,7 +87,6 @@ func (c *RelayController) HandleRelay(ctx *fasthttp.RequestCtx) {
 func (c *RelayController) concurrentRelay(req *models.SendRelayRequest, session *models.Session) (*models.SendRelayResponse, error) {
 	// Create a channel to receive results
 	resultCh := make(chan *models.SendRelayResponse, 1)
-	defer close(resultCh)
 	wg := sync.WaitGroup{}
 	for _, node := range session.Nodes {
 		node := node
@@ -100,7 +99,7 @@ func (c *RelayController) concurrentRelay(req *models.SendRelayRequest, session 
 			if err == nil {
 				select {
 				case resultCh <- response:
-				default:
+				default: // prevent blocking, already received a response.
 				}
 			}
 		}()

--- a/cmd/gateway_server/internal/controllers/relay.go
+++ b/cmd/gateway_server/internal/controllers/relay.go
@@ -118,7 +118,6 @@ func (c *RelayController) concurrentRelay(req *models.SendRelayRequest, session 
 		if !ok {
 			return nil, ErrRelayChannelClosed
 		}
-		close(resultCh) // Close the channel after receiving the first result
 		return result, nil
 	}
 }

--- a/internal/pokt_client_decorators/cached_client.go
+++ b/internal/pokt_client_decorators/cached_client.go
@@ -72,12 +72,13 @@ func (r *CachedClient) SendRelay(req *models.SendRelayRequest) (*models.SendRela
 		return nil, err
 	}
 
-	session, err := r.GetSession(&models.GetSessionRequest{AppPubKey: req.Signer.PublicKey, Chain: req.Chain})
+	session, err := pokt_v0.GetSessionFromRequest(r, req)
+
 	if err != nil {
 		return nil, err
 	}
 
-	req.Session = session.Session
+	req.Session = session
 	return r.PocketService.SendRelay(req)
 }
 

--- a/pkg/pokt/pokt_v0/basic_client.go
+++ b/pkg/pokt/pokt_v0/basic_client.go
@@ -70,7 +70,7 @@ func (r BasicClient) GetSession(req *models.GetSessionRequest) (*models.GetSessi
 func (r BasicClient) SendRelay(req *models.SendRelayRequest) (*models.SendRelayResponse, error) {
 
 	// Get a session from the request or retrieve from full node
-	session, err := r.getSessionFromRequest(req)
+	session, err := GetSessionFromRequest(r, req)
 
 	if err != nil {
 		return nil, err
@@ -221,11 +221,11 @@ func (r BasicClient) generateRelayProof(chainId string, sessionHeight uint, serv
 // Returns:
 //   - (*GetSessionResponse): Session response.
 //   - (error): Error, if any.
-func (r BasicClient) getSessionFromRequest(req *models.SendRelayRequest) (*models.Session, error) {
+func GetSessionFromRequest(pocketService PocketService, req *models.SendRelayRequest) (*models.Session, error) {
 	if req.Session != nil {
 		return req.Session, nil
 	}
-	sessionResp, err := r.GetSession(&models.GetSessionRequest{
+	sessionResp, err := pocketService.GetSession(&models.GetSessionRequest{
 		AppPubKey: req.Signer.PublicKey,
 		Chain:     req.Chain,
 	})


### PR DESCRIPTION
## Github issue

https://github.com/baaspoolsllc/os-gateway/issues/6

## Description

This PR addreses #6 by adding logic to do a concurrent request. This is used for demo purposes and to ensure the fastest response over conserving paying # of relays.

There is no limit to the number of concurrent relays as the intention is that with QoS, the concurrent relayer will specify the exact nodes to send relays to.

## Type of change

Please delete option that is not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related PRs

List related PRs below

| branch   | PR       |
| -------- | -------- |
| other_pr | [link]() |
