### PR TITLE
[CHORE] Add first part of tests for pocket basic client

### DIFF
--- a/pkg/pokt/pokt_v0/basic_client.go
+++ b/pkg/pokt/pokt_v0/basic_client.go
@@ -3,6 +3,7 @@ package pokt_v0
 import (
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/valyala/fasthttp"
+	"math/rand"
 	"os-gateway/pkg/common"
 	"os-gateway/pkg/pokt/pokt_v0/models"
 	"time"
@@ -84,7 +85,8 @@ func (r BasicClient) SendRelay(req *models.SendRelayRequest) (*models.SendRelayR
 
 	relayMetadata := &models.RelayMeta{BlockHeight: currentSessionHeight}
 
-	relayProof := generateRelayProof(req.Chain, currentSessionHeight, node.PublicKey, relayMetadata, req.Payload, req.Signer)
+	entropy := uint64(rand.Int63())
+	relayProof := generateRelayProof(entropy, req.Chain, currentSessionHeight, node.PublicKey, relayMetadata, req.Payload, req.Signer)
 
 	// Relay created, generating a request to the servicer
 	var sessionResponse models.SendRelayResponse

--- a/pkg/pokt/pokt_v0/basic_client.go
+++ b/pkg/pokt/pokt_v0/basic_client.go
@@ -1,13 +1,10 @@
 package pokt_v0
 
 import (
-	"encoding/hex"
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/valyala/fasthttp"
-	"math/rand"
 	"os-gateway/pkg/common"
 	"os-gateway/pkg/pokt/pokt_v0/models"
-	"slices"
 	"time"
 )
 
@@ -77,7 +74,7 @@ func (r BasicClient) SendRelay(req *models.SendRelayRequest) (*models.SendRelayR
 	}
 
 	// Get the preferred selected node, or chose a random one.
-	node, err := r.getNodeFromRequest(session, req.SelectedNodePubKey)
+	node, err := getNodeFromRequest(session, req.SelectedNodePubKey)
 
 	if err != nil {
 		return nil, err
@@ -87,14 +84,14 @@ func (r BasicClient) SendRelay(req *models.SendRelayRequest) (*models.SendRelayR
 
 	relayMetadata := &models.RelayMeta{BlockHeight: currentSessionHeight}
 
-	relayProof := r.generateRelayProof(req.Chain, currentSessionHeight, node.PublicKey, relayMetadata, req.Payload, req.Signer)
+	relayProof := generateRelayProof(req.Chain, currentSessionHeight, node.PublicKey, relayMetadata, req.Payload, req.Signer)
 
 	// Relay created, generating a request to the servicer
 	var sessionResponse models.SendRelayResponse
 	err = r.makeRequest(endpointSendRelay, "POST", &models.Relay{
 		Payload:    req.Payload,
 		Metadata:   relayMetadata,
-		RelayProof: &relayProof,
+		RelayProof: relayProof,
 	}, &sessionResponse, &node.ServiceUrl)
 
 	if err != nil {
@@ -161,125 +158,4 @@ func (r BasicClient) makeRequest(endpoint string, method string, requestData any
 		return pocketError
 	}
 	return ffjson.Unmarshal(response.Body(), responseModel)
-}
-
-// generateRelayProof generates a relay proof.
-// Parameters:
-//   - chainId: Blockchain ID.
-//   - sessionHeight: Session block height.
-//   - servicerPubKey: Servicer public key.
-//   - requestMetadata: Request metadata.
-//   - account: Ed25519 account used for signing.
-//
-// Returns:
-//   - models.RelayProof: Generated relay proof.
-func (r BasicClient) generateRelayProof(chainId string, sessionHeight uint, servicerPubKey string, relayMetadata *models.RelayMeta, reqPayload *models.Payload, account *models.Ed25519Account) models.RelayProof {
-	entropy := uint64(rand.Int63())
-	aat := account.GetAAT()
-
-	requestMetadata := models.RequestHashPayload{
-		Metadata: relayMetadata,
-		Payload:  reqPayload,
-	}
-
-	requestHash := requestMetadata.Hash()
-
-	unsignedAAT := &models.AAT{
-		Version:      aat.Version,
-		AppPubKey:    aat.AppPubKey,
-		ClientPubKey: aat.ClientPubKey,
-		Signature:    "",
-	}
-
-	proofObj := &models.RelayProofHashPayload{
-		RequestHash:        requestHash,
-		Entropy:            entropy,
-		SessionBlockHeight: sessionHeight,
-		ServicerPubKey:     servicerPubKey,
-		Blockchain:         chainId,
-		Signature:          "",
-		UnsignedAAT:        unsignedAAT.Hash(),
-	}
-
-	hashedPayload := common.Sha3_256Hash(proofObj)
-	hashSignature := hex.EncodeToString(account.Sign(hashedPayload))
-	return models.RelayProof{
-		RequestHash:        requestHash,
-		Entropy:            entropy,
-		SessionBlockHeight: sessionHeight,
-		ServicerPubKey:     servicerPubKey,
-		Blockchain:         chainId,
-		AAT:                aat,
-		Signature:          hashSignature,
-	}
-}
-
-// getSessionFromRequest obtains a session from a relay request.
-// Parameters:
-//   - req: SendRelayRequest instance containing the relay request parameters.
-//
-// Returns:
-//   - (*GetSessionResponse): Session response.
-//   - (error): Error, if any.
-func GetSessionFromRequest(pocketService PocketService, req *models.SendRelayRequest) (*models.Session, error) {
-	if req.Session != nil {
-		return req.Session, nil
-	}
-	sessionResp, err := pocketService.GetSession(&models.GetSessionRequest{
-		AppPubKey: req.Signer.PublicKey,
-		Chain:     req.Chain,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return sessionResp.Session, nil
-}
-
-// getNodeFromRequest obtains a node from a relay request.
-// Parameters:
-//   - req: SendRelayRequest instance containing the relay request parameters.
-//
-// Returns:
-//   - (*models.Node): Node instance.
-//   - (error): Error, if any.
-func (r BasicClient) getNodeFromRequest(session *models.Session, selectedNodePubKey string) (*models.Node, error) {
-	if selectedNodePubKey == "" {
-		return getRandomNodeOrError(session.Nodes, models.ErrSessionHasZeroNodes)
-	}
-	return findNodeOrError(session.Nodes, selectedNodePubKey, models.ErrNodeNotFound)
-}
-
-// getRandomNodeOrError gets a random node or returns an error if the node list is empty.
-// Parameters:
-//   - nodes: List of nodes.
-//   - err: Error to be returned if the node list is empty.
-//
-// Returns:
-//   - (*models.Node): Random node.
-//   - (error): Error, if any.
-func getRandomNodeOrError(nodes []*models.Node, err error) (*models.Node, error) {
-	node := common.GetRandomElement(nodes)
-	if node == nil {
-		return nil, err
-	}
-	return node, nil
-}
-
-// findNodeOrError finds a node by public key or returns an error if the node is not found.
-// Parameters:
-//   - nodes: List of nodes.
-//   - pubKey: Public key of the node to find.
-//   - err: Error to be returned if the node is not found.
-//
-// Returns:
-//   - (*models.Node): Found node.
-//   - (error): Error, if any.
-func findNodeOrError(nodes []*models.Node, pubKey string, err error) (*models.Node, error) {
-	idx := slices.IndexFunc(nodes, func(node *models.Node) bool {
-		return node.PublicKey == pubKey
-	})
-	if idx == -1 {
-		return nil, err
-	}
-	return nodes[idx], nil
 }

--- a/pkg/pokt/pokt_v0/generate_proof_bytes.go
+++ b/pkg/pokt/pokt_v0/generate_proof_bytes.go
@@ -2,13 +2,13 @@ package pokt_v0
 
 import (
 	"encoding/hex"
-	"math/rand"
 	"os-gateway/pkg/common"
 	"os-gateway/pkg/pokt/pokt_v0/models"
 )
 
 // generateRelayProof generates a relay proof.
 // Parameters:
+//   - entropy - random generated number to signify unique proof
 //   - chainId: Blockchain ID.
 //   - sessionHeight: Session block height.
 //   - servicerPubKey: Servicer public key.
@@ -17,8 +17,7 @@ import (
 //
 // Returns:
 //   - models.RelayProof: Generated relay proof.
-func generateRelayProof(chainId string, sessionHeight uint, servicerPubKey string, relayMetadata *models.RelayMeta, reqPayload *models.Payload, account *models.Ed25519Account) *models.RelayProof {
-	entropy := uint64(rand.Int63())
+func generateRelayProof(entropy uint64, chainId string, sessionHeight uint, servicerPubKey string, relayMetadata *models.RelayMeta, reqPayload *models.Payload, account *models.Ed25519Account) *models.RelayProof {
 	aat := account.GetAAT()
 
 	requestMetadata := models.RequestHashPayload{

--- a/pkg/pokt/pokt_v0/generate_proof_bytes.go
+++ b/pkg/pokt/pokt_v0/generate_proof_bytes.go
@@ -1,0 +1,59 @@
+package pokt_v0
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"os-gateway/pkg/common"
+	"os-gateway/pkg/pokt/pokt_v0/models"
+)
+
+// generateRelayProof generates a relay proof.
+// Parameters:
+//   - chainId: Blockchain ID.
+//   - sessionHeight: Session block height.
+//   - servicerPubKey: Servicer public key.
+//   - requestMetadata: Request metadata.
+//   - account: Ed25519 account used for signing.
+//
+// Returns:
+//   - models.RelayProof: Generated relay proof.
+func generateRelayProof(chainId string, sessionHeight uint, servicerPubKey string, relayMetadata *models.RelayMeta, reqPayload *models.Payload, account *models.Ed25519Account) *models.RelayProof {
+	entropy := uint64(rand.Int63())
+	aat := account.GetAAT()
+
+	requestMetadata := models.RequestHashPayload{
+		Metadata: relayMetadata,
+		Payload:  reqPayload,
+	}
+
+	requestHash := requestMetadata.Hash()
+
+	unsignedAAT := &models.AAT{
+		Version:      aat.Version,
+		AppPubKey:    aat.AppPubKey,
+		ClientPubKey: aat.ClientPubKey,
+		Signature:    "",
+	}
+
+	proofObj := &models.RelayProofHashPayload{
+		RequestHash:        requestHash,
+		Entropy:            entropy,
+		SessionBlockHeight: sessionHeight,
+		ServicerPubKey:     servicerPubKey,
+		Blockchain:         chainId,
+		Signature:          "",
+		UnsignedAAT:        unsignedAAT.Hash(),
+	}
+
+	hashedPayload := common.Sha3_256Hash(proofObj)
+	hashSignature := hex.EncodeToString(account.Sign(hashedPayload))
+	return &models.RelayProof{
+		RequestHash:        requestHash,
+		Entropy:            entropy,
+		SessionBlockHeight: sessionHeight,
+		ServicerPubKey:     servicerPubKey,
+		Blockchain:         chainId,
+		AAT:                aat,
+		Signature:          hashSignature,
+	}
+}

--- a/pkg/pokt/pokt_v0/generate_proof_bytes_test.go
+++ b/pkg/pokt/pokt_v0/generate_proof_bytes_test.go
@@ -1,0 +1,30 @@
+package pokt_v0
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os-gateway/pkg/pokt/pokt_v0/models"
+	"testing"
+)
+
+func Test_generateRelayProof(t *testing.T) {
+	type relayProofArgs struct {
+		entropy        uint64
+		chainId        string
+		sessionHeight  uint
+		servicerPubKey string
+		relayMetadata  *models.RelayMeta
+		reqPayload     *models.Payload
+		account        *models.Ed25519Account
+	}
+	tests := []struct {
+		name string
+		args relayProofArgs
+		want *models.RelayProof
+	}{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, generateRelayProof(tt.args.entropy, tt.args.chainId, tt.args.sessionHeight, tt.args.servicerPubKey, tt.args.relayMetadata, tt.args.reqPayload, tt.args.account), tt.want)
+		})
+	}
+}

--- a/pkg/pokt/pokt_v0/generate_proof_bytes_test.go
+++ b/pkg/pokt/pokt_v0/generate_proof_bytes_test.go
@@ -7,24 +7,34 @@ import (
 )
 
 func Test_generateRelayProof(t *testing.T) {
-	type relayProofArgs struct {
-		entropy        uint64
-		chainId        string
-		sessionHeight  uint
-		servicerPubKey string
-		relayMetadata  *models.RelayMeta
-		reqPayload     *models.Payload
-		account        *models.Ed25519Account
-	}
-	tests := []struct {
-		name string
-		args relayProofArgs
-		want *models.RelayProof
-	}{}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, generateRelayProof(tt.args.entropy, tt.args.chainId, tt.args.sessionHeight, tt.args.servicerPubKey, tt.args.relayMetadata, tt.args.reqPayload, tt.args.account), tt.want)
-		})
+	account, err := models.NewAccount("3fe64039816c44e8872e4ef981725b968422e3d49e95a1eb800707591df30fe374039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849")
+	assert.Equal(t, err, nil)
+
+	chainId := "0001"
+	sessionHeight := uint(1)
+	servicerPubKey := "0x"
+	relayMetadata := &models.RelayMeta{BlockHeight: sessionHeight}
+	requestPayload := &models.Payload{
+		Data:    "randomJsonPayload",
+		Method:  "post",
+		Path:    "",
+		Headers: nil,
 	}
+	entropy := uint64(1)
+	assert.Equal(t, generateRelayProof(entropy, chainId, sessionHeight, servicerPubKey, relayMetadata, requestPayload, account), &models.RelayProof{
+		Entropy:            1,
+		SessionBlockHeight: 1,
+		ServicerPubKey:     "0x",
+		Blockchain:         "0001",
+		AAT: &models.AAT{
+			Version:      "0.0.1",
+			AppPubKey:    "74039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+			ClientPubKey: "74039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+			Signature:    "f233ca857b4ada2ca4996e0da8c1761cfbc855edf282fc5a753d4631785946d6c2b08c781c84abbca2dc929de50008729079124e5c5c16921a81139279020a05",
+		},
+		Signature:   "befcc42130fb9e46fb9874acfb5bd8a9f783db60f86d1b1eb61cdba23fdb7e9e17544cb99afb480c9e1308532e07cdf6f4e2da27790f47dae30133725191b309",
+		RequestHash: "c5b64f9a7901ed8c3341f7440913a5ddd7b694dc7b4daeb234a47a9c42b653bb",
+	})
+
 }

--- a/pkg/pokt/pokt_v0/get_node_from_request.go
+++ b/pkg/pokt/pokt_v0/get_node_from_request.go
@@ -1,0 +1,56 @@
+package pokt_v0
+
+import (
+	"os-gateway/pkg/common"
+	"os-gateway/pkg/pokt/pokt_v0/models"
+	"slices"
+)
+
+// getNodeFromRequest obtains a node from a relay request.
+// Parameters:
+//   - req: SendRelayRequest instance containing the relay request parameters.
+//
+// Returns:
+//   - (*models.Node): Node instance.
+//   - (error): Error, if any.
+func getNodeFromRequest(session *models.Session, selectedNodePubKey string) (*models.Node, error) {
+	if selectedNodePubKey == "" {
+		return getRandomNodeOrError(session.Nodes, models.ErrSessionHasZeroNodes)
+	}
+	return findNodeOrError(session.Nodes, selectedNodePubKey, models.ErrNodeNotFound)
+}
+
+// getRandomNodeOrError gets a random node or returns an error if the node list is empty.
+// Parameters:
+//   - nodes: List of nodes.
+//   - err: Error to be returned if the node list is empty.
+//
+// Returns:
+//   - (*models.Node): Random node.
+//   - (error): Error, if any.
+func getRandomNodeOrError(nodes []*models.Node, err error) (*models.Node, error) {
+	node := common.GetRandomElement(nodes)
+	if node == nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// findNodeOrError finds a node by public key or returns an error if the node is not found.
+// Parameters:
+//   - nodes: List of nodes.
+//   - pubKey: Public key of the node to find.
+//   - err: Error to be returned if the node is not found.
+//
+// Returns:
+//   - (*models.Node): Found node.
+//   - (error): Error, if any.
+func findNodeOrError(nodes []*models.Node, pubKey string, err error) (*models.Node, error) {
+	idx := slices.IndexFunc(nodes, func(node *models.Node) bool {
+		return node.PublicKey == pubKey
+	})
+	if idx == -1 {
+		return nil, err
+	}
+	return nodes[idx], nil
+}

--- a/pkg/pokt/pokt_v0/get_node_from_request_test.go
+++ b/pkg/pokt/pokt_v0/get_node_from_request_test.go
@@ -1,0 +1,81 @@
+package pokt_v0
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os-gateway/pkg/pokt/pokt_v0/models"
+	"testing"
+)
+
+func Test_findNodeOrError(t *testing.T) {
+	type args struct {
+		nodes  []*models.Node
+		pubKey string
+		err    error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.Node
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findNodeOrError(tt.args.nodes, tt.args.pubKey, tt.args.err)
+			if !tt.wantErr(t, err, fmt.Sprintf("findNodeOrError(%v, %v, %v)", tt.args.nodes, tt.args.pubKey, tt.args.err)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "findNodeOrError(%v, %v, %v)", tt.args.nodes, tt.args.pubKey, tt.args.err)
+		})
+	}
+}
+
+func Test_getNodeFromRequest(t *testing.T) {
+	type args struct {
+		session            *models.Session
+		selectedNodePubKey string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.Node
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNodeFromRequest(tt.args.session, tt.args.selectedNodePubKey)
+			if !tt.wantErr(t, err, fmt.Sprintf("getNodeFromRequest(%v, %v)", tt.args.session, tt.args.selectedNodePubKey)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "getNodeFromRequest(%v, %v)", tt.args.session, tt.args.selectedNodePubKey)
+		})
+	}
+}
+
+func Test_getRandomNodeOrError(t *testing.T) {
+	type args struct {
+		nodes []*models.Node
+		err   error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.Node
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getRandomNodeOrError(tt.args.nodes, tt.args.err)
+			if !tt.wantErr(t, err, fmt.Sprintf("getRandomNodeOrError(%v, %v)", tt.args.nodes, tt.args.err)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "getRandomNodeOrError(%v, %v)", tt.args.nodes, tt.args.err)
+		})
+	}
+}

--- a/pkg/pokt/pokt_v0/get_session_from_request.go
+++ b/pkg/pokt/pokt_v0/get_session_from_request.go
@@ -2,7 +2,7 @@ package pokt_v0
 
 import "os-gateway/pkg/pokt/pokt_v0/models"
 
-// getSessionFromRequest obtains a session from a relay request.
+// GetSessionFromRequest obtains a session from a relay request.
 // Parameters:
 //   - req: SendRelayRequest instance containing the relay request parameters.
 //

--- a/pkg/pokt/pokt_v0/get_session_from_request.go
+++ b/pkg/pokt/pokt_v0/get_session_from_request.go
@@ -1,0 +1,24 @@
+package pokt_v0
+
+import "os-gateway/pkg/pokt/pokt_v0/models"
+
+// getSessionFromRequest obtains a session from a relay request.
+// Parameters:
+//   - req: SendRelayRequest instance containing the relay request parameters.
+//
+// Returns:
+//   - (*GetSessionResponse): Session response.
+//   - (error): Error, if any.
+func GetSessionFromRequest(pocketService PocketService, req *models.SendRelayRequest) (*models.Session, error) {
+	if req.Session != nil {
+		return req.Session, nil
+	}
+	sessionResp, err := pocketService.GetSession(&models.GetSessionRequest{
+		AppPubKey: req.Signer.PublicKey,
+		Chain:     req.Chain,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sessionResp.Session, nil
+}

--- a/pkg/pokt/pokt_v0/get_session_from_request_test.go
+++ b/pkg/pokt/pokt_v0/get_session_from_request_test.go
@@ -1,0 +1,32 @@
+package pokt_v0
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os-gateway/pkg/pokt/pokt_v0/models"
+	"testing"
+)
+
+func TestGetSessionFromRequest(t *testing.T) {
+	type args struct {
+		pocketService PocketService
+		req           *models.SendRelayRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.Session
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetSessionFromRequest(tt.args.pocketService, tt.args.req)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetSessionFromRequest(%v, %v)", tt.args.pocketService, tt.args.req)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetSessionFromRequest(%v, %v)", tt.args.pocketService, tt.args.req)
+		})
+	}
+}

--- a/pkg/pokt/pokt_v0/get_session_from_request_test.go
+++ b/pkg/pokt/pokt_v0/get_session_from_request_test.go
@@ -1,32 +1,84 @@
 package pokt_v0
 
 import (
-	"fmt"
+	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"os-gateway/mocks"
 	"os-gateway/pkg/pokt/pokt_v0/models"
 	"testing"
 )
 
 func TestGetSessionFromRequest(t *testing.T) {
+
+	mockSession := &models.Session{
+		Nodes: []*models.Node{
+			{
+				ServiceUrl: "example-node-1",
+				PublicKey:  "example-pub-key-1",
+			},
+		},
+		SessionHeader: &models.SessionHeader{
+			SessionHeight: uint(1),
+		},
+	}
+
+	mockErr := errors.New("failure")
+
 	type args struct {
 		pocketService PocketService
 		req           *models.SendRelayRequest
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *models.Session
-		wantErr assert.ErrorAssertionFunc
+		name            string
+		generateArgs    func() args
+		expectedSession *models.Session
+		expectedErr     error
 	}{
-		// TODO: Add test cases.
+		{
+			name: "SessionFromInnerRequest",
+			generateArgs: func() args {
+				return args{
+					pocketService: nil,
+					req:           &models.SendRelayRequest{Session: mockSession},
+				}
+			},
+			expectedErr:     nil,
+			expectedSession: mockSession,
+		},
+		{
+			name: "SessionFromPocketServiceError",
+			generateArgs: func() args {
+				mockPocketService := new(mocks.PocketService)
+				mockPocketService.EXPECT().GetSession(mock.Anything).Return(nil, mockErr).Times(1)
+				return args{
+					pocketService: mockPocketService,
+					req:           &models.SendRelayRequest{Session: nil, Signer: &models.Ed25519Account{}},
+				}
+			},
+			expectedErr:     mockErr,
+			expectedSession: nil,
+		},
+		{
+			name: "SessionFromPocketServiceSuccess",
+			generateArgs: func() args {
+				mockPocketService := new(mocks.PocketService)
+				mockPocketService.EXPECT().GetSession(mock.Anything).Return(&models.GetSessionResponse{Session: mockSession}, nil).Times(1)
+				return args{
+					pocketService: mockPocketService,
+					req:           &models.SendRelayRequest{Session: nil, Signer: &models.Ed25519Account{}},
+				}
+			},
+			expectedErr:     nil,
+			expectedSession: mockSession,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetSessionFromRequest(tt.args.pocketService, tt.args.req)
-			if !tt.wantErr(t, err, fmt.Sprintf("GetSessionFromRequest(%v, %v)", tt.args.pocketService, tt.args.req)) {
-				return
-			}
-			assert.Equalf(t, tt.want, got, "GetSessionFromRequest(%v, %v)", tt.args.pocketService, tt.args.req)
+			args := tt.generateArgs()
+			session, err := GetSessionFromRequest(args.pocketService, args.req)
+			assert.Equal(t, err, tt.expectedErr)
+			assert.Equal(t, session, tt.expectedSession)
 		})
 	}
 }

--- a/pkg/pokt/pokt_v0/models/ed25519-account_test.go
+++ b/pkg/pokt/pokt_v0/models/ed25519-account_test.go
@@ -1,0 +1,59 @@
+package models
+
+import (
+	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewAccount(t *testing.T) {
+	tests := []struct {
+		name              string
+		privateKey        string
+		expectedPublicKey string
+		expectedAddress   string
+		err               error
+	}{
+		{
+			name:              "BadPrivateKey",
+			privateKey:        "badKey",
+			expectedPublicKey: "",
+			expectedAddress:   "",
+			err:               ErrInvalidPrivateKey,
+		},
+		{
+			name:              "Success",
+			privateKey:        "3fe64039816c44e8872e4ef981725b968422e3d49e95a1eb800707591df30fe374039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+			expectedPublicKey: "74039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+			expectedAddress:   "d873127df524d172276e4da8193a2e2b19ef825f",
+			err:               nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acc, err := NewAccount(tt.privateKey)
+			assert.Equal(t, err, tt.err)
+			if err == nil {
+				assert.Equal(t, acc.PublicKey, tt.expectedPublicKey)
+				assert.Equal(t, acc.Address, tt.expectedAddress)
+			}
+		})
+	}
+}
+
+func TestEd25519Account_GetAAT(t *testing.T) {
+	a, err := NewAccount("3fe64039816c44e8872e4ef981725b968422e3d49e95a1eb800707591df30fe374039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, &AAT{
+		Version:      "0.0.1",
+		AppPubKey:    "74039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+		ClientPubKey: "74039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849",
+		Signature:    "f233ca857b4ada2ca4996e0da8c1761cfbc855edf282fc5a753d4631785946d6c2b08c781c84abbca2dc929de50008729079124e5c5c16921a81139279020a05",
+	}, a.GetAAT())
+}
+
+func TestEd25519Account_Sign(t *testing.T) {
+	a, err := NewAccount("3fe64039816c44e8872e4ef981725b968422e3d49e95a1eb800707591df30fe374039dbe881dd2744e2e0c469cc2241e1e45f14af6975dd89079d22938377849")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, hex.EncodeToString(a.Sign([]byte("TestMessage"))), "6cf23f8aa00793ef6aec4d3c408f5be249f01ddc96778f3ea03ef8fcdd301e09ce175fbcb97778b222de57469857d99ef97ad978dc49992f70a108aafd3d3001")
+}


### PR DESCRIPTION
## Github issue
https://github.com/baaspoolsllc/os-gateway/issues/16
## Description

This PR:
- seperates generate proof functionality and adds a test for it.
- adds tests for ed25519 account
- adds tests for finding a random node from a request
- add tests for finding a session from a request

Deferred for followup PR: There will be a future PR to mock out the HTTP responses for `makeRequest` in `basic_client.go` which will allow us to have full coverage on the pocket client. It's been deferred because mocking out fastify for client is not trivial

## Type of change

Please delete option that is not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related PRs

List related PRs below

| branch   | PR       |
| -------- | -------- |
| other_pr | [link]() |
