### PR TITLE
Benchmarking and QoS Endpoint Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Every release candidate is published to https://github.com/pokt-network/gateway-
 ## Docker Compose
 There is an all-inclusive docker-compose file available for development [docker-compose.yml](docker-compose.yml)
 
+## Minimum Hardware Requirements to run
+- 1GB of RAM
+- 1GB of storage
+- 4 vCPUs
+
 ## Creating a DB Migration
 Migrations are like version control for your database, allowing your team to define and share the application's database schema definition.
 Before running a migration make sure to install the go lang migration cli on your machine.

--- a/cmd/gateway_server/internal/common/response-json.go
+++ b/cmd/gateway_server/internal/common/response-json.go
@@ -13,15 +13,17 @@ import (
 type ErrorResponse struct {
 	Message string `json:"message"`
 	Status  int    `json:"status"`
+	Error   error  `json:"error"`
 }
 
 // JSONError creates a JSON-formatted error response and sends it to the client.
 // It takes the fasthttp.RequestCtx, error message, and HTTP status code as parameters.
-func JSONError(ctx *fasthttp.RequestCtx, message string, statusCode int) {
+func JSONError(ctx *fasthttp.RequestCtx, message string, statusCode int, err error) {
 	// Create an ErrorResponse instance with the provided message and status code.
 	errorResponse := ErrorResponse{
 		Message: message,
 		Status:  statusCode,
+		Error:   err,
 	}
 
 	// Marshal the ErrorResponse instance into JSON format.

--- a/cmd/gateway_server/internal/config/dot_env_config_provider.go
+++ b/cmd/gateway_server/internal/config/dot_env_config_provider.go
@@ -60,7 +60,7 @@ func (c DotEnvGlobalConfigProvider) GetPoktRPCRequestTimeout() time.Duration {
 
 // GetSessionCacheTTL returns the time value for session to expire in cache.
 func (c DotEnvGlobalConfigProvider) GetSessionCacheTTL() time.Duration {
-	return c.poktRPCRequestTimeout
+	return c.sessionCacheTTL
 }
 
 // GetEnvironmentStage returns the EnvironmentStage value.

--- a/cmd/gateway_server/internal/controllers/pokt_apps.go
+++ b/cmd/gateway_server/internal/controllers/pokt_apps.go
@@ -50,18 +50,18 @@ func (c *PoktAppsController) AddApplication(ctx *fasthttp.RequestCtx) {
 	var body addApplicationBody
 	err := ffjson.Unmarshal(ctx.PostBody(), &body)
 	if err != nil {
-		common.JSONError(ctx, "Faiiled to unmarshal req", fasthttp.StatusInternalServerError)
+		common.JSONError(ctx, "Faiiled to unmarshal req", fasthttp.StatusInternalServerError, err)
 		return
 	}
 
 	account, err := pokt_models.NewAccount(body.PrivateKey)
 	if err != nil {
-		common.JSONError(ctx, "Faiiled to convert to ed25519 account", fasthttp.StatusBadRequest)
+		common.JSONError(ctx, "Faiiled to convert to ed25519 account", fasthttp.StatusBadRequest, err)
 		return
 	}
 	_, err = c.query.InsertPoktApplications(context.Background(), account.PrivateKey, c.secretProvider.GetPoktApplicationsEncryptionKey())
 	if err != nil {
-		common.JSONError(ctx, "Something went wrong", fasthttp.StatusInternalServerError)
+		common.JSONError(ctx, "Something went wrong", fasthttp.StatusInternalServerError, err)
 		return
 	}
 	ctx.SetStatusCode(fasthttp.StatusCreated)
@@ -75,7 +75,7 @@ func (c *PoktAppsController) DeleteApplication(ctx *fasthttp.RequestCtx) {
 	uuid.Set(applicationId)
 	_, err := c.query.DeletePoktApplication(context.Background(), uuid)
 	if err != nil {
-		common.JSONError(ctx, "Something went wrong", fasthttp.StatusInternalServerError)
+		common.JSONError(ctx, "Something went wrong", fasthttp.StatusInternalServerError, err)
 		return
 	}
 	ctx.SetStatusCode(fasthttp.StatusOK)

--- a/cmd/gateway_server/internal/controllers/pokt_apps.go
+++ b/cmd/gateway_server/internal/controllers/pokt_apps.go
@@ -37,7 +37,7 @@ func NewPoktAppsController(appRegistry apps_registry.AppsRegistryService, query 
 // GetAll returns all the apps in the registry
 func (c *PoktAppsController) GetAll(ctx *fasthttp.RequestCtx) {
 	applications := c.appRegistry.GetApplications()
-	appsPublic := []*models.PoktApplication{}
+	appsPublic := []*models.PublicPoktApplication{}
 	for _, app := range applications {
 		appsPublic = append(appsPublic, transform.ToPoktApplication(app))
 	}

--- a/cmd/gateway_server/internal/controllers/qos_nodes.go
+++ b/cmd/gateway_server/internal/controllers/qos_nodes.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"github.com/valyala/fasthttp"
+	"go.uber.org/zap"
+	"pokt_gateway_server/cmd/gateway_server/internal/common"
+	"pokt_gateway_server/cmd/gateway_server/internal/models"
+	"pokt_gateway_server/cmd/gateway_server/internal/transform"
+	"pokt_gateway_server/internal/session_registry"
+)
+
+// QosNodeController handles requests for staked applications
+type QosNodeController struct {
+	logger          *zap.Logger
+	sessionRegistry session_registry.SessionRegistryService
+}
+
+// NewQosNodeController  creates a new instance of QosNodeController.
+func NewQosNodeController(sessionRegistry session_registry.SessionRegistryService, logger *zap.Logger) *QosNodeController {
+	return &QosNodeController{sessionRegistry: sessionRegistry, logger: logger}
+}
+
+// GetAll returns all the qos nodes in the registry and exposes public information about them.
+func (c *QosNodeController) GetAll(ctx *fasthttp.RequestCtx) {
+	qosNodes := []*models.PublicQosNode{}
+	for _, nodes := range c.sessionRegistry.GetNodesMap() {
+		for _, node := range nodes.Value() {
+			qosNodes = append(qosNodes, transform.ToPublicQosNode(node))
+		}
+	}
+	common.JSONSuccess(ctx, qosNodes, fasthttp.StatusOK)
+}

--- a/cmd/gateway_server/internal/controllers/relay.go
+++ b/cmd/gateway_server/internal/controllers/relay.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"github.com/valyala/fasthttp"
 	"go.uber.org/zap"
 	"pokt_gateway_server/cmd/gateway_server/internal/common"
@@ -30,7 +31,7 @@ func (c *RelayController) HandleRelay(ctx *fasthttp.RequestCtx) {
 
 	// Check if the chain ID is empty or has an incorrect length.
 	if chainID == "" || len(chainID) != chainIdLength {
-		common.JSONError(ctx, "Incorrect chain id", fasthttp.StatusBadRequest)
+		common.JSONError(ctx, "Incorrect chain id", fasthttp.StatusBadRequest, nil)
 		return
 	}
 
@@ -45,7 +46,7 @@ func (c *RelayController) HandleRelay(ctx *fasthttp.RequestCtx) {
 
 	if err != nil {
 		c.logger.Error("Error relaying", zap.Error(err))
-		common.JSONError(ctx, "Something went wrong", fasthttp.StatusInternalServerError)
+		common.JSONError(ctx, fmt.Sprintf("Something went wrong %v", err), fasthttp.StatusInternalServerError, err)
 		return
 	}
 

--- a/cmd/gateway_server/internal/middleware/x-api-key.go
+++ b/cmd/gateway_server/internal/middleware/x-api-key.go
@@ -25,6 +25,6 @@ func XAPIKeyAuth(h fasthttp.RequestHandler, provider config2.SecretProvider) fas
 			return
 		}
 		// Request Basic Authentication otherwise
-		common.JSONError(ctx, "Unauthorized, invalid x-api-key header", fasthttp.StatusUnauthorized)
+		common.JSONError(ctx, "Unauthorized, invalid x-api-key header", fasthttp.StatusUnauthorized, nil)
 	}
 }

--- a/cmd/gateway_server/internal/models/pokt_application.go
+++ b/cmd/gateway_server/internal/models/pokt_application.go
@@ -1,6 +1,6 @@
 package models
 
-type PoktApplication struct {
+type PublicPoktApplication struct {
 	ID        string   `json:"id"`
 	MaxRelays int      `json:"max_relays"`
 	Chains    []string `json:"chain"`

--- a/cmd/gateway_server/internal/models/qos_node.go
+++ b/cmd/gateway_server/internal/models/qos_node.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+type PublicQosNode struct {
+	ServiceUrl      string    `json:"service_url"`
+	Chain           string    `json:"chain"`
+	SessionHeight   uint      `json:"session_height"`
+	AppPublicKey    string    `json:"app_public_key"`
+	TimeoutUntil    time.Time `json:"timeout_until"`
+	TimeoutReason   string    `json:"timeout_reason"`
+	LastKnownErr    string    `json:"last_known_err"`
+	IsHeathy        bool      `json:"is_heathy"`
+	IsSynced        bool      `json:"is_synced"`
+	LastKnownHeight uint64    `json:"last_known_height"`
+}

--- a/cmd/gateway_server/internal/transform/pokt_application.go
+++ b/cmd/gateway_server/internal/transform/pokt_application.go
@@ -5,8 +5,8 @@ import (
 	internal_model "pokt_gateway_server/internal/apps_registry/models"
 )
 
-func ToPoktApplication(app *internal_model.PoktApplicationSigner) *models.PoktApplication {
-	return &models.PoktApplication{
+func ToPoktApplication(app *internal_model.PoktApplicationSigner) *models.PublicPoktApplication {
+	return &models.PublicPoktApplication{
 		ID:        app.ID,
 		MaxRelays: int(app.NetworkApp.MaxRelays),
 		Chains:    app.NetworkApp.Chains,

--- a/cmd/gateway_server/internal/transform/qos_node.go
+++ b/cmd/gateway_server/internal/transform/qos_node.go
@@ -1,0 +1,21 @@
+package transform
+
+import (
+	"pokt_gateway_server/cmd/gateway_server/internal/models"
+	internal_model "pokt_gateway_server/internal/node_selector_service/models"
+)
+
+func ToPublicQosNode(node *internal_model.QosNode) *models.PublicQosNode {
+	return &models.PublicQosNode{
+		ServiceUrl:      node.MorseNode.ServiceUrl,
+		Chain:           node.GetChain(),
+		SessionHeight:   node.PocketSession.SessionHeader.SessionHeight,
+		AppPublicKey:    node.AppSigner.PublicKey,
+		TimeoutReason:   string(node.GetTimeoutReason()),
+		LastKnownErr:    node.GetLastKnownErrorStr(),
+		IsHeathy:        node.IsHealthy(),
+		IsSynced:        node.IsSynced(),
+		LastKnownHeight: node.GetLastKnownHeight(),
+		TimeoutUntil:    node.GetTimeoutUntil(),
+	}
+}

--- a/cmd/gateway_server/main.go
+++ b/cmd/gateway_server/main.go
@@ -86,6 +86,11 @@ func main() {
 	poktAppsRouter.POST("/", middleware.XAPIKeyAuth(poktAppsController.AddApplication, gatewayConfigProvider))
 	poktAppsRouter.DELETE("/{app_id}", middleware.XAPIKeyAuth(poktAppsController.DeleteApplication, gatewayConfigProvider))
 
+	// Create qos controller for debugging purposes
+	qosNodeController := controllers.NewQosNodeController(sessionRegistry, logger.Named("qos_node_controller"))
+	qosNodeRouter := r.Group("/qosnodes")
+	qosNodeRouter.GET("/", middleware.XAPIKeyAuth(qosNodeController.GetAll, gatewayConfigProvider))
+
 	// Add Middleware for Generic E2E Prom Tracking
 	p := fasthttpprometheus.NewPrometheus("fasthttp")
 	fastpHandler := p.WrapHandler(r)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "${HTTP_SERVER_PORT}:${HTTP_SERVER_PORT}"
     env_file:
       - ./.env
+    networks:
+      - bridged_network
 
   postgres:
     image: postgres:latest
@@ -17,9 +19,15 @@ services:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    networks:
+      - bridged_network
 
 volumes:
   postgres_data:
+
+networks:
+  bridged_network:
+    driver: bridge

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -4,10 +4,11 @@ The Gateway Server currently exposes all its API endpoints in form of HTTP endpo
 
 `x-api-key`  is an api key set by the gateway operator to transmit internal private data
 
-| Endpoint            | HTTP METHOD | Description                                                                                | HEADERS     | Request Parameters                       |
-|---------------------|-------------|--------------------------------------------------------------------------------------------|-------------|------------------------------------------|
-| `/relay/{chain_id}` | ANY         | The main endpoint for your reverse proxy to send requests too                              | ANY         | `{chain_id}` - Network identifier        |
-| `/metrics`          | GET         | Metadata on the gateway server performance for observability purposes                      | N/A         | N/A                                      |
-| `/poktapp`          | POST        | Adds an existing app stake to the appstake database (not recommended due to security)      | `x-api-key` | `private_key` - private key of app stake |
-| `/poktapp`          | DELETE      | Removes an existing app stake from the appstake database (not recommended due to security) | `x-api-key` | `app_id` -  id of the appstake           |
-| `/poktapp`          | GET         | A list of all the available app stakes                                                     | `x-api-key` | N/A                                      |
+| Endpoint            | HTTP METHOD | Description                                                                                                                                        | HEADERS     | Request Parameters                       |
+|---------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|------------------------------------------|
+| `/relay/{chain_id}` | ANY         | The main endpoint for your reverse proxy to send requests too                                                                                      | ANY         | `{chain_id}` - Network identifier        |
+| `/metrics`          | GET         | Metadata on the gateway server performance for observability purposes                                                                              | N/A         | N/A                                      |
+| `/poktapp`          | POST        | Adds an existing app stake to the appstake database (not recommended due to security)                                                              | `x-api-key` | `private_key` - private key of app stake |
+| `/poktapp`          | DELETE      | Removes an existing app stake from the appstake database (not recommended due to security)                                                         | `x-api-key` | `app_id` -  id of the appstake           |
+| `/poktapp`          | GET         | A list of all the available app stakes                                                                                                             | `x-api-key` | N/A                                      |
+| `/qosnodes`         | GET         | A list of nodes and public QoS state such as healthiness and last known error. This can be used to expose to node operators to improve visibility. | `x-api-key` | N/A                                      |

--- a/docs/benchmarks/03-2024-benchmark.md
+++ b/docs/benchmarks/03-2024-benchmark.md
@@ -1,0 +1,17 @@
+# March 2024 Benchmark (RC 0.1.0)
+
+## Benchmark Purpose
+The purpose of this benchmark is to comprehensively assess the performance metrics, particularly CPU and Memory behaviors, incurred while serving requests through the gateway server. Specifically, this evaluation aims to gauge the efficiency of various operations such as JSON serialization, IO handling, cryptographic signing, and asynchronous background processes involved in sending requests to the POKT Network.
+
+## Benchmark Environment
+### Infrastructure:
+- **POKT Testnet**: The benchmark is conducted within the environment of the POKT Testnet to simulate real-world conditions accurately.
+- **RPC Method eth_chainId**: The benchmark uses a consistent time RPC method, eth_chainId, chosen deliberately to isolate the impact of the gateway server overhead. It's noteworthy that the computational load of sending a request to the POKT Network remains independent of the specific RPC Method employed.
+- **Gateway Server Instance**: The gateway server is deployed on a dedicated instance, denoted by [x], ensuring controlled conditions for performance evaluation.
+- **Tooling**: Utilizes Vegeta, a versatile HTTP load testing too
+
+## Results
+[Results section will provide detailed insights into the observed metrics, including CPU utilization, memory consumption, response times, throughput, and any other pertinent performance indicators.]
+
+## Summary
+[Summary section will encapsulate key findings and conclusions drawn from the benchmarking exercise, highlighting any noteworthy trends, optimizations, or areas for improvement identified during the evaluation process.]

--- a/docs/benchmarks/03-2024-benchmark.md
+++ b/docs/benchmarks/03-2024-benchmark.md
@@ -1,17 +1,16 @@
 # March 2024 Benchmark (RC 0.1.0)
 
 ## Benchmark Purpose
-The purpose of this benchmark is to comprehensively assess the performance metrics, particularly CPU and Memory behaviors, incurred while serving requests through the gateway server. Specifically, this evaluation aims to gauge the efficiency of various operations such as JSON serialization, IO handling, cryptographic signing, and asynchronous background processes involved in sending requests to the POKT Network.
+The purpose of this benchmark is to comprehensively assess the performance metrics, particularly CPU and Memory behaviors, incurred while serving requests through the gateway server. Specifically, this evaluation aims to gauge the efficiency of various operations involved with sending a relay such as JSON serialization, IO handling, cryptographic signing, and asynchronous background processes (QoS checks).
 
 ## Benchmark Environment
-### Infrastructure:
 - **POKT Testnet**: The benchmark is conducted within the environment of the POKT Testnet to simulate real-world conditions accurately.
-- **RPC Method eth_chainId**: The benchmark uses a consistent time RPC method, eth_chainId, chosen deliberately to isolate the impact of the gateway server overhead. It's noteworthy that the computational load of sending a request to the POKT Network remains independent of the specific RPC Method employed.
-- **Gateway Server Instance**: The gateway server is deployed on a dedicated instance, denoted by [x], ensuring controlled conditions for performance evaluation.
+- **RPC Method: eth_chainId**: The benchmark uses a consistent time RPC method, eth_chainId, chosen deliberately to isolate the impact of the gateway server overhead. It's noteworthy that the computational overhead of sending a request to the POKT Network remains independent of the specific RPC Method employed, hence why `eth_chainId` is chosen.
+- **Hardware**: The gateway server is deployed on a dedicated instance, denoted by [x], ensuring controlled conditions for performance evaluation.
 - **Tooling**: Utilizes Vegeta, a versatile HTTP load testing too
 
 ## Results
-[Results section will provide detailed insights into the observed metrics, including CPU utilization, memory consumption, response times, throughput, and any other pertinent performance indicators.]
+[Results section will provide detailed insights into the observed metrics, including CPU utilization, memory consumption, throughput, and any other pertinent performance indicators.]
 
 ## Summary
 [Summary section will encapsulate key findings and conclusions drawn from the benchmarking exercise, highlighting any noteworthy trends, optimizations, or areas for improvement identified during the evaluation process.]

--- a/docs/benchmarks/03-2024-benchmark.md
+++ b/docs/benchmarks/03-2024-benchmark.md
@@ -1,4 +1,4 @@
-# March 2024 Benchmark (RC 0.1.0)
+# March 2024 Benchmark (RC 0.1.0) (WIP)
 
 ## Benchmark Purpose
 The purpose of this benchmark is to comprehensively assess the performance metrics, particularly CPU and Memory behaviors, incurred while serving requests through the gateway server. Specifically, this evaluation aims to gauge the efficiency of various operations involved with sending a relay such as JSON serialization, IO handling, cryptographic signing, and asynchronous background processes (QoS checks).

--- a/internal/node_selector_service/checks/error_handler.go
+++ b/internal/node_selector_service/checks/error_handler.go
@@ -35,12 +35,8 @@ func isKickableSessionErr(err error) bool {
 		return true
 	}
 	// Fallback in the event the error is not parsed correctly due to node operator configurations / custom clients, resort to a simple string check
-	pocketError, ok := err.(relayer_models.PocketRPCError)
-	if ok {
-		return strings.Contains(pocketError.Message, errPocketOverServiceMsg) || strings.Contains(pocketError.Message, errPocketMaximumEvidenceSealedMsg) || strings.Contains(pocketError.Message, errPocketInvalidServicerMsg)
-	}
 	// node runner cannot serve with expired ssl
-	if err != nil && strings.Contains(err.Error(), errHttpSSLExpired) {
+	if err != nil && (strings.Contains(err.Error(), errHttpSSLExpired) || strings.Contains(err.Error(), errPocketOverServiceMsg) || strings.Contains(err.Error(), errPocketMaximumEvidenceSealedMsg) || strings.Contains(err.Error(), errPocketInvalidServicerMsg)) {
 		return true
 	}
 	return false
@@ -53,10 +49,10 @@ func isTimeoutError(err error) bool {
 	}
 	pocketError, ok := err.(relayer_models.PocketRPCError)
 	if ok {
-		// Fallback in the event the error is not parsed correctly due to node operator configurations / custom clients, resort to a simple string check
-		return pocketError.HttpCode >= 500 || strings.Contains(pocketError.Message, errPocketRequestTimeoutMsg) || strings.Contains(pocketError.Message, errPocketInvalidBlockHeightMsg)
+		return pocketError.HttpCode >= 500
 	}
-	return err == fasthttp.ErrTimeout || err == fasthttp.ErrDialTimeout || err == fasthttp.ErrTLSHandshakeTimeout || err != nil && strings.Contains(err.Error(), errHttpNoSuchHostMsg)
+	// Fallback in the event the error is not parsed correctly due to node operator configurations / custom clients, resort to a simple string check
+	return err == fasthttp.ErrTimeout || err == fasthttp.ErrDialTimeout || err == fasthttp.ErrTLSHandshakeTimeout || err != nil && (strings.Contains(err.Error(), errHttpNoSuchHostMsg) || strings.Contains(err.Error(), errPocketRequestTimeoutMsg) || strings.Contains(err.Error(), errPocketInvalidBlockHeightMsg))
 }
 
 // DefaultPunishNode generic punisher for whenever a node returns an error independent of a specific check

--- a/internal/node_selector_service/checks/error_handler.go
+++ b/internal/node_selector_service/checks/error_handler.go
@@ -16,12 +16,20 @@ const timeoutErrorPenalty = time.Second * 15
 const kickOutSessionPenalty = time.Hour * 24
 
 const (
-	errOverServiceMsg           = "the max number of relays serviced for this node is exceeded"
-	errMaximumEvidenceSealedMsg = "the evidence is sealed, either max relays reached or claim already submitted"
+	errPocketInvalidServicerMsg       = "failed to find correct servicer PK"
+	errPocketInvalidBlockHeightMsg    = "invalid block height"
+	errPocketRequestTimeoutMsg        = "request timeout"
+	errPocketOverServiceMsg           = "the max number of relays serviced for this node is exceeded"
+	errPocketMaximumEvidenceSealedMsg = "the evidence is sealed, either max relays reached or claim already submitted"
 )
 
-// isMaximumRelaysServicedErr - determines if a node should be kicked from a session to send relays
-func isMaximumRelaysServicedErr(err error) bool {
+const (
+	errHttpSSLExpired    = "tls: failed to verify certificate"
+	errHttpNoSuchHostMsg = "no such host"
+)
+
+// isKickableSessionErr - determines if a node should be kicked from a session to send relays
+func isKickableSessionErr(err error) bool {
 	// If evidence is sealed or the node has already overserviced, the node should no longer receive relays.
 	if err == relayer_models.ErrPocketEvidenceSealed || err == relayer_models.ErrPocketCoreOverService {
 		return true
@@ -29,29 +37,38 @@ func isMaximumRelaysServicedErr(err error) bool {
 	// Fallback in the event the error is not parsed correctly due to node operator configurations / custom clients, resort to a simple string check
 	pocketError, ok := err.(relayer_models.PocketRPCError)
 	if ok {
-		return strings.Contains(pocketError.Message, errOverServiceMsg) || strings.Contains(pocketError.Message, errMaximumEvidenceSealedMsg)
+		return strings.Contains(pocketError.Message, errPocketOverServiceMsg) || strings.Contains(pocketError.Message, errPocketMaximumEvidenceSealedMsg) || strings.Contains(pocketError.Message, errPocketInvalidServicerMsg)
+	}
+	// node runner cannot serve with expired ssl
+	if err != nil && strings.Contains(err.Error(), errHttpSSLExpired) {
+		return true
 	}
 	return false
 }
 
 func isTimeoutError(err error) bool {
+	// If Invalid block height, pocket  is not caught up to latest session
+	if err == relayer_models.ErrPocketCoreInvalidBlockHeight {
+		return true
+	}
 	pocketError, ok := err.(relayer_models.PocketRPCError)
 	if ok {
-		return pocketError.HttpCode >= 500 || strings.Contains(pocketError.Message, "request timeout")
+		// Fallback in the event the error is not parsed correctly due to node operator configurations / custom clients, resort to a simple string check
+		return pocketError.HttpCode >= 500 || strings.Contains(pocketError.Message, errPocketRequestTimeoutMsg) || strings.Contains(pocketError.Message, errPocketInvalidBlockHeightMsg)
 	}
-	return err == fasthttp.ErrTimeout || err == fasthttp.ErrDialTimeout || err == fasthttp.ErrTLSHandshakeTimeout
+	return err == fasthttp.ErrTimeout || err == fasthttp.ErrDialTimeout || err == fasthttp.ErrTLSHandshakeTimeout || err != nil && strings.Contains(err.Error(), errHttpNoSuchHostMsg)
 }
 
 // DefaultPunishNode generic punisher for whenever a node returns an error independent of a specific check
 func DefaultPunishNode(err error, node *models.QosNode, logger *zap.Logger) bool {
-	if isMaximumRelaysServicedErr(err) {
-		node.SetTimeoutUntil(time.Now().Add(kickOutSessionPenalty), models.MaximumRelaysTimeout)
+	if isKickableSessionErr(err) {
+		node.SetTimeoutUntil(time.Now().Add(kickOutSessionPenalty), models.MaximumRelaysTimeout, err)
 		return true
 	}
 	if isTimeoutError(err) {
-		node.SetTimeoutUntil(time.Now().Add(timeoutErrorPenalty), models.NodeResponseTimeout)
+		node.SetTimeoutUntil(time.Now().Add(timeoutErrorPenalty), models.NodeResponseTimeout, err)
 		return true
 	}
-	logger.Sugar().Errorw("unknown error for punishing node", "node", node.MorseNode.ServiceUrl)
+	logger.Sugar().Warnw("uncategorized error detected from pocket node", "node", node.MorseNode.ServiceUrl, "err", err)
 	return false
 }

--- a/internal/node_selector_service/checks/error_handler.go
+++ b/internal/node_selector_service/checks/error_handler.go
@@ -17,7 +17,7 @@ const kickOutSessionPenalty = time.Hour * 24
 
 const (
 	errPocketInvalidServicerMsg       = "failed to find correct servicer PK"
-	errPocketInvalidBlockHeightMsg    = "invalid block height"
+	errPocketInvalidBlockHeightMsg    = "the block height passed is invalid"
 	errPocketRequestTimeoutMsg        = "request timeout"
 	errPocketOverServiceMsg           = "the max number of relays serviced for this node is exceeded"
 	errPocketMaximumEvidenceSealedMsg = "the evidence is sealed, either max relays reached or claim already submitted"

--- a/internal/node_selector_service/checks/evm_data_integrity_check/evm_data_integrity_check.go
+++ b/internal/node_selector_service/checks/evm_data_integrity_check/evm_data_integrity_check.go
@@ -112,7 +112,7 @@ func (c *EvmDataIntegrityCheck) Perform() {
 	for _, nodeResp := range nodeResponsePairs {
 		if nodeResp.result.Result.Hash != majorityBlockHash {
 			c.logger.Sugar().Errorw("punishing node for failed data integrity check", "node", nodeResp.node.MorseNode.ServiceUrl, "nodeBlockHash", nodeResp.result.Result, "trustedSourceBlockHash", majorityBlockHash)
-			nodeResp.node.SetTimeoutUntil(time.Now().Add(dataIntegrityTimePenalty), models.DataIntegrityTimeout)
+			nodeResp.node.SetTimeoutUntil(time.Now().Add(dataIntegrityTimePenalty), models.DataIntegrityTimeout, fmt.Errorf("evmDataIntegrityCheck: nodeBlockHash %s, trustedSourceBlockHash %s", nodeResp.result.Result, majorityBlockHash))
 		}
 	}
 

--- a/internal/node_selector_service/checks/evm_height_check/evm_height_check.go
+++ b/internal/node_selector_service/checks/evm_height_check/evm_height_check.go
@@ -122,7 +122,7 @@ func (c *EvmHeightCheck) Perform() {
 			c.logger.Sugar().Infow("node is out of sync", "node", node.MorseNode.ServiceUrl, "heightDifference", heightDifference, "nodeSyncedHeight", node.GetLastKnownHeight(), "highestNodeHeight", highestNodeHeight, "chain", node.GetChain())
 			// Punish Node specifically due to timeout.
 			node.SetSynced(false)
-			node.SetTimeoutUntil(time.Now().Add(evmHeightCheckPenalty), models.OutOfSyncTimeout)
+			node.SetTimeoutUntil(time.Now().Add(evmHeightCheckPenalty), models.OutOfSyncTimeout, fmt.Errorf("evmHeightCheck: heightDifference: %d, nodeSyncedHeight: %d, highestNodeHeight: %d", heightDifference, node.GetLastKnownHeight(), highestNodeHeight))
 		} else {
 			node.SetSynced(true)
 		}

--- a/internal/node_selector_service/node_selector_service.go
+++ b/internal/node_selector_service/node_selector_service.go
@@ -10,6 +10,7 @@ import (
 	"pokt_gateway_server/internal/session_registry"
 	"pokt_gateway_server/pkg/common"
 	"pokt_gateway_server/pkg/pokt/pokt_v0"
+	"sort"
 	"time"
 )
 
@@ -48,21 +49,56 @@ func NewNodeSelectorService(sessionRegistry session_registry.SessionRegistryServ
 }
 
 func (q NodeSelectorClient) FindNode(chainId string) (*models.QosNode, bool) {
-	var healthyNodes []*models.QosNode
-	nodes, found := q.sessionRegistry.GetNodesByChain(chainId)
-	if !found {
+
+	nodes, ok := q.sessionRegistry.GetNodesByChain(chainId)
+	if !ok {
 		return nil, false
 	}
+
+	// Filter nodes by health
+	healthyNodes := filterByHealthyNodes(nodes)
+
+	// Find a node that's closer to session height
+	sortedSessionHeights, nodeMap := filterBySessionHeightNodes(healthyNodes)
+	for _, sessionHeight := range sortedSessionHeights {
+		node, ok := common.GetRandomElement(nodeMap[sessionHeight])
+		if ok {
+			return node, true
+		}
+	}
+	return nil, false
+}
+
+func filterBySessionHeightNodes(nodes []*models.QosNode) ([]uint, map[uint][]*models.QosNode) {
+	nodesBySessionHeight := map[uint][]*models.QosNode{}
+
+	// Create map to retrieve nodes by session height
+	for _, r := range nodes {
+		sessionHeight := r.PocketSession.SessionHeader.SessionHeight
+		nodesBySessionHeight[sessionHeight] = append(nodesBySessionHeight[sessionHeight], r)
+	}
+
+	// Create slice to hold sorted session heights
+	var sortedSessionHeights []uint
+	for sessionHeight := range nodesBySessionHeight {
+		sortedSessionHeights = append(sortedSessionHeights, sessionHeight)
+	}
+
+	// Sort the slice of session heights
+	sort.Slice(sortedSessionHeights, func(i, j int) bool {
+		return sortedSessionHeights[i] < sortedSessionHeights[j]
+	})
+	return sortedSessionHeights, nodesBySessionHeight
+}
+func filterByHealthyNodes(nodes []*models.QosNode) []*models.QosNode {
+	var healthyNodes []*models.QosNode
+
 	for _, r := range nodes {
 		if r.IsHealthy() {
 			healthyNodes = append(healthyNodes, r)
 		}
 	}
-	node, ok := common.GetRandomElement(healthyNodes)
-	if !ok {
-		return nil, false
-	}
-	return node, true
+	return healthyNodes
 }
 
 func (q NodeSelectorClient) startJobChecker() {

--- a/internal/node_selector_service/node_selector_service.go
+++ b/internal/node_selector_service/node_selector_service.go
@@ -84,10 +84,11 @@ func filterBySessionHeightNodes(nodes []*models.QosNode) ([]uint, map[uint][]*mo
 		sortedSessionHeights = append(sortedSessionHeights, sessionHeight)
 	}
 
-	// Sort the slice of session heights
+	// Sort the slice of session heights by descending order
 	sort.Slice(sortedSessionHeights, func(i, j int) bool {
-		return sortedSessionHeights[i] < sortedSessionHeights[j]
+		return sortedSessionHeights[i] > sortedSessionHeights[j]
 	})
+
 	return sortedSessionHeights, nodesBySessionHeight
 }
 func filterByHealthyNodes(nodes []*models.QosNode) []*models.QosNode {

--- a/internal/session_registry/cached_session_registry_service.go
+++ b/internal/session_registry/cached_session_registry_service.go
@@ -61,6 +61,9 @@ type CachedSessionRegistryService struct {
 	concurrentDispatchPool chan struct{}
 	logger                 *zap.Logger
 	lastPrimedHeight       uint64
+
+	// Lock used to synchronize inserting sessions and append sessions nodes.
+	sessionCacheLock sync.RWMutex
 	// Consist of sessions for a given app stake+chain+height. Cache exists to prevent round trip request
 	sessionCache ttl_cache.TTLCacheService[string, *Session]
 	// Cache that contains all nodes by chain (chainId -> Nodes)
@@ -75,7 +78,9 @@ func NewCachedSessionRegistryService(poktClient pokt_v0.PocketService, appRegist
 	return cachedRegistry
 }
 
-func (c CachedSessionRegistryService) GetNodesByChain(chainId string) ([]*qos_models.QosNode, bool) {
+func (c *CachedSessionRegistryService) GetNodesByChain(chainId string) ([]*qos_models.QosNode, bool) {
+	c.sessionCacheLock.RLock()
+	defer c.sessionCacheLock.RUnlock()
 	nodes := c.chainNodes.Get(chainId)
 	if nodes == nil {
 		return nil, false
@@ -83,11 +88,13 @@ func (c CachedSessionRegistryService) GetNodesByChain(chainId string) ([]*qos_mo
 	return nodes.Value(), true
 }
 
-func (c CachedSessionRegistryService) GetNodesMap() map[string]*ttlcache.Item[string, []*qos_models.QosNode] {
+func (c *CachedSessionRegistryService) GetNodesMap() map[string]*ttlcache.Item[string, []*qos_models.QosNode] {
+	c.sessionCacheLock.RLock()
+	defer c.sessionCacheLock.RUnlock()
 	return c.chainNodes.Items()
 }
 
-func (c CachedSessionRegistryService) GetSession(req *models.GetSessionRequest) (*Session, error) {
+func (c *CachedSessionRegistryService) GetSession(req *models.GetSessionRequest) (*Session, error) {
 	cacheKey := getSessionCacheKey(req)
 	cachedSession := c.sessionCache.Get(cacheKey)
 	isCached := cachedSession != nil && cachedSession.Value() != nil
@@ -129,7 +136,7 @@ func (c CachedSessionRegistryService) GetSession(req *models.GetSessionRequest) 
 		return nil, errors.New("cannot find signer from session")
 	}
 
-	var wrappedNodes []*qos_models.QosNode
+	wrappedNodes := []*qos_models.QosNode{}
 	for _, a := range response.Session.Nodes {
 		wrappedNodes = append(wrappedNodes, &qos_models.QosNode{
 			PocketSession: response.Session,
@@ -145,20 +152,26 @@ func (c CachedSessionRegistryService) GetSession(req *models.GetSessionRequest) 
 	// Update session cache
 	c.sessionCache.Set(cacheKey, wrappedSession, ttlcache.DefaultTTL)
 
+	c.sessionCacheLock.Lock()
+	defer c.sessionCacheLock.Unlock()
 	chainNodeCacheKey := req.Chain
-	nodes := c.chainNodes.Get(chainNodeCacheKey)
-	if nodes == nil || nodes.Value() == nil {
+	if !c.chainNodes.Has(chainNodeCacheKey) {
 		// No values in session and chain cache
 		c.chainNodes.Set(chainNodeCacheKey, wrappedNodes, ttlcache.DefaultTTL)
 	} else {
 		// Values already exist in session and chain cache, so append value.
-		c.chainNodes.Set(chainNodeCacheKey, append(nodes.Value(), wrappedNodes...), ttlcache.DefaultTTL)
+		item := c.chainNodes.Get(chainNodeCacheKey)
+		if item != nil {
+			chainNodesAppended := append(item.Value(), wrappedNodes...)
+			c.chainNodes.Set(chainNodeCacheKey, chainNodesAppended, ttlcache.DefaultTTL)
+		}
 	}
+
 	c.lastFailure = time.Time{} // Reset last failure since it succeeded
 	return wrappedSession, nil
 }
 
-func (c CachedSessionRegistryService) startSessionUpdater() {
+func (c *CachedSessionRegistryService) startSessionUpdater() {
 	ticker := time.Tick(sessionPrimerInterval)
 	go func() {
 		for {
@@ -174,7 +187,7 @@ func (c CachedSessionRegistryService) startSessionUpdater() {
 }
 
 // shouldPrimeSession: Track the latest time we primed a session and only prime if there's a new session
-func (c CachedSessionRegistryService) shouldPrimeSessions(latestHeight uint64) bool {
+func (c *CachedSessionRegistryService) shouldPrimeSessions(latestHeight uint64) bool {
 	isSessionBlock := latestHeight%blocksPerSession == 1
 	isNewSessionBlock := latestHeight > c.lastPrimedHeight
 	return c.lastPrimedHeight == 0 || isSessionBlock && isNewSessionBlock
@@ -182,7 +195,7 @@ func (c CachedSessionRegistryService) shouldPrimeSessions(latestHeight uint64) b
 
 // primeSession: used as a background service to optimistically grab sessions
 // before relays are handled to prevent unneeded round trips.
-func (c CachedSessionRegistryService) primeSessions() error {
+func (c *CachedSessionRegistryService) primeSessions() error {
 
 	resp, err := c.poktClient.GetLatestBlockHeight()
 
@@ -234,7 +247,7 @@ func (c CachedSessionRegistryService) primeSessions() error {
 // shouldBackOffDispatchFailure: whenever pokt nodes receive too many dispatches at once, it results in overloaded pokt nodes
 // and subsequent dispatch failures.
 // TODO: Optimization: Allow for % backoff/retry mechanism instead of constant backoff threshhold.
-func (c CachedSessionRegistryService) shouldBackoffDispatchFailure() bool {
+func (c *CachedSessionRegistryService) shouldBackoffDispatchFailure() bool {
 	return !c.lastFailure.IsZero() && time.Since(c.lastFailure) < backoffThreshold
 }
 

--- a/internal/session_registry/session_registry_service.go
+++ b/internal/session_registry/session_registry_service.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Session struct {
-	IsValid bool
-	Nodes   []*qos_models.QosNode
+	IsValid       bool
+	PocketSession *models.Session
+	Nodes         []*qos_models.QosNode
 }
 
 type SessionRegistryService interface {

--- a/pkg/pokt/pokt_v0/models/block.go
+++ b/pkg/pokt/pokt_v0/models/block.go
@@ -2,5 +2,5 @@
 package models
 
 type GetLatestBlockHeightResponse struct {
-	Height uint64 `json:"height"`
+	Height uint `json:"height"`
 }

--- a/pkg/pokt/pokt_v0/models/block_ffjson.go
+++ b/pkg/pokt/pokt_v0/models/block_ffjson.go
@@ -161,11 +161,11 @@ mainparse:
 
 handle_Height:
 
-	/* handler: j.Height type=uint64 kind=uint64 quoted=false*/
+	/* handler: j.Height type=uint kind=uint quoted=false*/
 
 	{
 		if tok != fflib.FFTok_integer && tok != fflib.FFTok_null {
-			return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for uint64", tok))
+			return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for uint", tok))
 		}
 	}
 
@@ -181,7 +181,7 @@ handle_Height:
 				return fs.WrapErr(err)
 			}
 
-			j.Height = uint64(tval)
+			j.Height = uint(tval)
 
 		}
 	}

--- a/pkg/ttl_cache/ttl_cache.go
+++ b/pkg/ttl_cache/ttl_cache.go
@@ -7,6 +7,7 @@ import (
 )
 
 type TTLCacheService[K comparable, V any] interface {
+	Has(key K) bool
 	Get(key K, opts ...ttlcache.Option[K, V]) *ttlcache.Item[K, V]
 	Set(key K, value V, ttl time.Duration) *ttlcache.Item[K, V]
 	Start()


### PR DESCRIPTION
## Github issue
https://github.com/pokt-network/gateway-server/issues/22

## Description
Previously Grove would expose error logs in a postgres database that Poktscan would parse and index, but this has been deprecated and node operators struggle with visibility.

This PR adds a new endpoint `/qosnodes` which returns the state of QoS nodes with redacted information. This endpoint can be used to expose to node operators. Ultimately this allows node operators to determine why they aren't healthy or misconfigurated which overall improves the state of the network.

Additionally, this PR adds in additional timeout errors that node operators return after post benchmarking, and adds the benchmarking results.

Other misc changes:
- Updated logs on session primer and improved logic on when to prime

## Type of change

Please delete option that is not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related PRs

List related PRs below

| branch   | PR       |
| -------- | -------- |
| other_pr | [link]() |
