### PR TITLE
Fix incorrect timeout setting and clarify env var docs

### DIFF
--- a/docs/quick-onboarding-guide.md
+++ b/docs/quick-onboarding-guide.md
@@ -39,16 +39,16 @@ Create an encryption password for your app stake keys. This password will be use
 Fill out the `.env` variables for the gateway server. This can be done by injecting environment variables directly or using a `.env` file.
 
 ### Env Variables Description
-| Variable Name                      | Description                                         | Example Value                                                                                     |
-|------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `POKT_RPC_FULL_HOST`               | Used for dispatching sessions                       | `https://pokt-testnet-rpc.nodies.org` (a complimentary testnet dispatcher URL provided by Nodies) |
-| `HTTP_SERVER_PORT`                 | Gateway server port                                 | `8080`                                                                                            |
-| `POKT_RPC_TIMEOUT`                 | Max response time for a POKT node to respond        | `10s`                                                                                             |
-| `POKT_RPC_TIMEOUT`                 | Max response time for an altruist backup to respond | `10s`                                                                                             |
-| `ENVIRONMENT_STAGE`                | Log verbosity                                       | `development`, `production`                                                                       |
-| `SESSION_CACHE_TTL`                | Duration for sessions to stay in cache              | `75m`                                                                                             |
-| `POKT_APPLICATIONS_ENCRYPTION_KEY` | User-generated encryption key                       | `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`                                                                |
-| `DB_CONNECTION_URL`                | PostgreSQL Database connection URL                  | `postgres://user:password@localhost:5432/postgres`                                                |
+| Variable Name                       | Description                                         | Example Value                                                                                     |
+|-------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `POKT_RPC_FULL_HOST`                | Used for dispatching sessions                       | `https://pokt-testnet-rpc.nodies.org` (a complimentary testnet dispatcher URL provided by Nodies) |
+| `HTTP_SERVER_PORT`                  | Gateway server port                                 | `8080`                                                                                            |
+| `POKT_RPC_TIMEOUT`                  | Max response time for a POKT node to respond        | `10s`                                                                                             |
+| `ALTRUIST_REQUEST_TIMEOUT`          | Max response time for an altruist backup to respond | `10s`                                                                                             |
+| `ENVIRONMENT_STAGE`                 | Log verbosity                                       | `development`, `production`                                                                       |
+| `SESSION_CACHE_TTL`                 | Duration for sessions to stay in cache              | `75m`                                                                                             |
+| `POKT_APPLICATIONS_ENCRYPTION_KEY`  | User-generated encryption key                       | `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`                                                                |
+| `DB_CONNECTION_URL`                 | PostgreSQL Database connection URL                  | `postgres://user:password@localhost:5432/postgres`                                                |
 
 See [.env.sample](..%2F.env.sample) for a sample.
 

--- a/internal/relayer/relayer.go
+++ b/internal/relayer/relayer.go
@@ -222,7 +222,7 @@ func (r *Relayer) getPocketRequestTimeout(chainId string) time.Duration {
 	if !ok {
 		return r.globalConfigProvider.GetPoktRPCRequestTimeout()
 	}
-	configTime, err := time.ParseDuration(chainConfig.AltruistRequestTimeoutDuration.String)
+	configTime, err := time.ParseDuration(chainConfig.PocketRequestTimeoutDuration.String)
 	if err != nil {
 		return r.globalConfigProvider.GetPoktRPCRequestTimeout()
 	}


### PR DESCRIPTION
## Github issue

https://github.com/pokt-network/gateway-server/issues/28

## Description

- Correct the chain config attribute for POKT request timeouts in `relayer.go`.
- Disambiguate `POKT_RPC_TIMEOUT` usage in the quick onboarding guide to prevent setup confusion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
