### PR TITLE
RC 0.2.0

### DIFF
--- a/cmd/gateway_server/internal/models/qos_node.go
+++ b/cmd/gateway_server/internal/models/qos_node.go
@@ -11,7 +11,7 @@ type PublicQosNode struct {
 	TimeoutUntil    time.Time `json:"timeout_until"`
 	TimeoutReason   string    `json:"timeout_reason"`
 	LastKnownErr    string    `json:"last_known_err"`
-	IsHeathy        bool      `json:"is_heathy"`
+	IsHealthy       bool      `json:"is_healthy"`
 	IsSynced        bool      `json:"is_synced"`
 	LastKnownHeight uint64    `json:"last_known_height"`
 	P90Latency      float64   `json:"p90_latency"`

--- a/cmd/gateway_server/internal/models/qos_node.go
+++ b/cmd/gateway_server/internal/models/qos_node.go
@@ -3,6 +3,7 @@ package models
 import "time"
 
 type PublicQosNode struct {
+	NodePublicKey   string    `json:"node_public_key"`
 	ServiceUrl      string    `json:"service_url"`
 	Chain           string    `json:"chain"`
 	SessionHeight   uint      `json:"session_height"`

--- a/cmd/gateway_server/internal/transform/qos_node.go
+++ b/cmd/gateway_server/internal/transform/qos_node.go
@@ -12,6 +12,7 @@ func ToPublicQosNode(node *internal_model.QosNode) *models.PublicQosNode {
 		latency = 0.0
 	}
 	return &models.PublicQosNode{
+		NodePublicKey:   node.MorseNode.PublicKey,
 		ServiceUrl:      node.MorseNode.ServiceUrl,
 		Chain:           node.GetChain(),
 		SessionHeight:   node.MorseSession.SessionHeader.SessionHeight,

--- a/cmd/gateway_server/internal/transform/qos_node.go
+++ b/cmd/gateway_server/internal/transform/qos_node.go
@@ -19,7 +19,7 @@ func ToPublicQosNode(node *internal_model.QosNode) *models.PublicQosNode {
 		AppPublicKey:    node.MorseSigner.PublicKey,
 		TimeoutReason:   string(node.GetTimeoutReason()),
 		LastKnownErr:    node.GetLastKnownErrorStr(),
-		IsHeathy:        node.IsHealthy(),
+		IsHealthy:       node.IsHealthy(),
 		IsSynced:        node.IsSynced(),
 		LastKnownHeight: node.GetLastKnownHeight(),
 		TimeoutUntil:    node.GetTimeoutUntil(),

--- a/internal/node_selector_service/checks/error_handler.go
+++ b/internal/node_selector_service/checks/error_handler.go
@@ -17,7 +17,7 @@ const kickOutSessionPenalty = time.Hour * 24
 
 var (
 	errsKickSession = []string{"failed to find correct servicer PK", "the max number of relays serviced for this node is exceeded", "the evidence is sealed, either max relays reached or claim already submitted"}
-	errsTimeout     = []string{"connection refused", "the request block height is out of sync with the current block height", "no route to host", "unexpected EOF", "i/o timeout", "tls: failed to verify certificate", "no such host", "the block height passed is invalid", "request timeout"}
+	errsTimeout     = []string{"connection refused", "the request block height is out of sync with the current block height", "no route to host", "unexpected EOF", "i/o timeout", "tls: failed to verify certificate", "no such host", "the block height passed is invalid", "request timeout", "error executing the http request"}
 )
 
 func doesErrorContains(errsSubString []string, err error) bool {

--- a/internal/node_selector_service/checks/evm_data_integrity_check/evm_data_integrity_check.go
+++ b/internal/node_selector_service/checks/evm_data_integrity_check/evm_data_integrity_check.go
@@ -108,6 +108,11 @@ func (c *EvmDataIntegrityCheck) Perform() {
 
 	majorityBlockHash := findMajorityBlockHash(nodeResponseCounts)
 
+	// Blcok hash must not be empty
+	if majorityBlockHash == "" {
+		return
+	}
+
 	// Penalize other node operators with a timeout if they don't attest with same block hash.
 	for _, nodeResp := range nodeResponsePairs {
 		if nodeResp.result.Result.Hash != majorityBlockHash {


### PR DESCRIPTION
## Github issue



## Description
- Fixes typo in `is_heathy` -> `is_healthy` in `qosnodes` endpoint (reason for the minor version upgrade)
- Adds `node_public_key` to `qosnodes` endpoint to enable Poktscan to scrape data and provide QoS data publically
- https://github.com/pokt-network/gateway-server/pull/29 
- Adds more tags to relayer prometheus metrics (chain id) and for histogram latency (chain id, altruist, and success) for increased observability oversight.
- Improve QoS data integrity check by checking if the selected source of truth returns an actual block hash (otherwise skip and try again)

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related PRs

List related PRs below

| branch   | PR       |
| -------- | -------- |
| other_pr | [link]() |
