### PR TITLE
Updated .env.sample to correctly match docker-compose file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,6 @@ POKT_RPC_TIMEOUT=5s
 ENVIRONMENT_STAGE=development
 POKT_APPLICATIONS_ENCRYPTION_KEY=
 SESSION_CACHE_TTL=75m
-DB_CONNECTION_URL=postgres://postgres:mypassword@localhost:5432/postgres?sslmode=disable
+DB_CONNECTION_URL=postgres://myuser:mypassword@postgres:5432/postgres?sslmode=disable
 API_KEY=
 ALTRUIST_REQUEST_TIMEOUT=10s


### PR DESCRIPTION
# Github issue

N/A

## Description

This PR updates the .env.sample file's DB connection string to match what is required in the docker-compose file. The current file requires you to update `localhost` to `postgres` for the gateway service in the docker-compose application to work as expected. While this would cause users who run a Postgres server directly on the host without Docker Compose to have to make updates, I am assuming that the majority of gateway operators would be running Postgres on a separate server, and would have to make updates to their connection string regardless. Therefore, I think it's better to make the .env example match with the docker-compose file to ensure that `docker-compose up -d` results in a working application. 

## Type of change

Please delete option that is not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related PRs

N/A
