### PR TITLE
Enhance migration script to support specific and complete migrations/rollbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,34 @@ This command will generate a up and down migration in `db_migrations`
 DB Migrations are applied upon server start, but as well, it can be applied manually through:
 ```sh
 ./scripts/migration.sh {--down or --up} {number_of_times} 
-./scripts/migration.sh -d 1
-./scripts/migration.sh -u 1
 ```
+
+### Usage
+
+#### Apply Migrations
+
+- To apply all migrations:
+  ```sh
+  ./scripts/migration.sh --up
+  ```
+
+- To apply a specific number of migrations:
+  ```sh
+  ./scripts/migration.sh --up 2
+  ```
+
+#### Rollback Migrations
+Make sure to provide either the number of migrations to rollback or the `--all` flag to rollback all migrations.
+
+- To roll back a specific number of migrations:
+  ```sh
+  ./scripts/migration.sh --down 2
+  ```
+
+- To roll back all migrations:
+  ```sh
+  ./scripts/migration.sh --down --all
+  ```
 
 ## Running Tests
 Install Mockery with

--- a/scripts/migration.sh
+++ b/scripts/migration.sh
@@ -36,7 +36,7 @@ case $key in
         DOWN_MIGRATION_NUMBER="$2"
         shift
     else
-        echo "Error: Down migration requires a specific number of migrations or -all flag to revert all migrations."
+        echo "Error: Down migration requires a specific number of migrations or --all flag to revert all migrations."
         exit 1
     fi
     shift # past argument


### PR DESCRIPTION
## Github issue

https://github.com/pokt-network/gateway-server/issues/37

## Description

These changes modify the migration handling script to support more flexible migration operations. 

It introduces the ability to apply all pending migrations by default when using the `--up` flag without specifying a number or if a number of migrations is specified with `--up`, only migrate up to that many migrations.

For the `--down` flag, it now requires a specific number of migrations to revert or the explicit use of the `--all` option to roll back all migrations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

