### PR TITLE
Issue-43 Add Node Health Prom Metrics per Chain

### DIFF
--- a/internal/node_selector_service/models/qos_node.go
+++ b/internal/node_selector_service/models/qos_node.go
@@ -69,7 +69,7 @@ func NewQosNode(morseNode *models.Node, pocketSession *models.Session, appSigner
 }
 
 func (n *QosNode) IsHealthy() bool {
-	return !n.isInTimeout() && n.IsSynced()
+	return !n.IsInTimeout() && n.IsSynced()
 }
 
 func (n *QosNode) IsSynced() bool {
@@ -80,7 +80,7 @@ func (n *QosNode) SetSynced(synced bool) {
 	n.synced = synced
 }
 
-func (n *QosNode) isInTimeout() bool {
+func (n *QosNode) IsInTimeout() bool {
 	return !n.timeoutUntil.IsZero() && time.Now().Before(n.timeoutUntil)
 }
 

--- a/internal/session_registry/cached_session_registry_service.go
+++ b/internal/session_registry/cached_session_registry_service.go
@@ -60,7 +60,7 @@ func init() {
 	healthyNodesPerChainGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cached_client_session_healthy_nodes",
-			Help: "Number of healthy nodes per chain",
+			Help: "Number of healthy (synced + not in timeout) nodes per chain",
 		},
 		[]string{"chain_id"},
 	)


### PR DESCRIPTION
## Github issue

https://github.com/pokt-network/gateway-server/issues/43

## Description

This PR enhances the node health metrics by introducing detailed per-chain gauges.  
It adds three new metrics: 
- Number of healthy nodes per chain.
- Number of synced nodes per chain.
- Number of nodes in timeout per chain. 

These metrics will be exported in Prometheus format and available for scraping at the `/metrics` endpoint, providing improved visibility and monitoring capabilities.

## Type of change

Please delete option that is not relevant.
- [x] New feature (non-breaking change which adds functionality)
